### PR TITLE
Add resume as blog post

### DIFF
--- a/contents/articles/resume/index.md
+++ b/contents/articles/resume/index.md
@@ -1,0 +1,183 @@
+---
+title: "Resume – Dan Marshall"
+description: "Senior full-stack engineer with 11+ years of experience in .NET, JVM, microservices, and production AI systems."
+date: 2026-03-02
+author: "Dan Marshall"
+template: article.pug
+tags: []
+---
+
+# Dan Marshall
+
+Senior full-stack engineer with 11+ years of delivering enterprise .NET and JVM systems. Deep expertise in microservices, event-driven architecture, and production AI integration. Strong advocate for TDD, pair programming, and collaborative engineering practices that improve code quality and team velocity.
+
+---
+
+## Qualifications
+
+**Bachelor of Science** (Mathematics and Computer Science)
+University of South Africa (UNISA)
+
+---
+
+## Skills
+
+### Back-end Development
+
+- **C# / .NET**: Expert knowledge, .NET Framework 3.5 through .NET Core 9
+- **JVM Stack**: Spring Boot, Kotlin, Java
+- **Architecture**: Microservices, event-driven architecture, DI, CQRS, DDD, Clean Architecture
+- **Azure**: App Services, Functions, Service Bus, Azure SQL, Blob Storage, App Insights, Entra
+- **AWS**: Bedrock, ECS, SQS, S3
+- **Testing**: NUnit, xUnit, MSTest 2, JUnit, Selenium, Storybook, TDD, mutation and integration testing
+- **API Development**: ASP.NET WebAPI, FastEndpoints, GraphQL, Spring Boot
+- **Messaging**: MassTransit with Azure Service Bus and event streaming
+- **Data Access**: Entity Framework Core, Dapper, raw SQL
+- **Databases**: SQL Server, PostgreSQL, MySQL
+- **Security**: ASP.NET Identity, OAuth2, JWT, Microsoft.Identity, Azure AD / Entra ID
+- **Libraries**: MediatR, Serilog, Polly, AutoMapper, Refit, Quartz.NET, OpenAPI
+- **DevOps**: CI/CD with Azure DevOps, TeamCity, Octopus Deploy, PowerShell, Docker
+- **Observability**: OpenTelemetry, Seq, OpenSearch, Application Insights SDK, Serilog Sinks
+
+### AI/ML Integration
+
+- **Production AI Systems**: OpenAI Platform, Claude API, LangChain4j, prompt engineering
+- **Applications**: Automation, multimodal analysis, guardrails
+- **Platforms**: AWS Bedrock, OpenAI, local LLMs, Hugging Face Transformers
+
+### Front-end Development
+
+- **Frameworks**: TypeScript/JavaScript with React, Angular, Vite, Vitest, and ASP.NET MVC
+- **UI Design**: CSS, Tailwind CSS, Material UI
+
+### General
+
+- **Version Control**: Git, GitHub, Bitbucket, Azure Repos
+- **Agile Tools**: Jira, Confluence, Azure DevOps Boards, Teams, Slack
+- **Practices**: TDD, pair/mob programming, code review, mentorship
+- **Operating Systems**: macOS, Windows, Linux, iOS, Android
+
+---
+
+## Employment
+
+### Reapit — [reapit.com](https://www.reapit.com)
+**Senior AI Engineer** | September 2025 – February 2026
+
+- Workshopped, built, and deployed an AI-driven property inspection system using AWS Bedrock, generating structured assessment reports constrained by business rules.
+- Forked the LangChain4j framework to add Bedrock guardrail support when unavailable upstream. Modular architecture enabled a seamless swap to the official implementation within one day when released.
+- Optimised LLM costs through strategic model selection balancing accuracy, features, performance, and token usage.
+- Advised cross-functional teams on practical AI use cases.
+- Self-directed adoption of the Kotlin/Spring Boot/AWS ecosystem, delivering production features while supporting the team with JVM implementation patterns.
+
+---
+
+### RACT (Royal Automobile Club of Tasmania) — [ract.com.au](https://www.ract.com.au)
+**Senior Software Engineer – Back-end** | June 2024 – July 2025
+
+- Applied Clean Architecture and DDD to enhance testability, scalability, and code clarity.
+- Involved in pilot program to develop AI coding rulesets and best practices.
+- Migrated and modernised core components from .NET Framework 4.7.2 to .NET 9.
+- Built resilient microservices using MassTransit, WebAPI, GraphQL, and SQL Server.
+- Collaborated with cross-functional teams to deliver scalable, well-tested features aligned with business requirements.
+
+---
+
+### National Grower Register — [ngr.com.au](https://www.ngr.com.au)
+**Senior Full-Stack Engineer** | November 2023 – May 2024
+
+- Co-developed a modular online form solution (Flexidocs) using Clean Architecture and DDD, replacing an outdated system.
+- Designed modern functional React 18 components with TypeScript and Tailwind CSS.
+- Provided guidance on C# programming, OOP, AI tools, and testing best practices.
+- Researched and selected sustainable technologies to support long-term goals.
+- Improved legacy code with unit test coverage, enabling safe refactoring.
+- Contributed to technical documentation and Agile processes.
+- Mentored junior staff.
+
+---
+
+### CloudMonitor — [cloudmonitor.ai](https://www.cloudmonitor.ai)
+**Lead Azure / Back-end Engineer** | June 2023 – November 2023
+
+- Conceptualised, developed, and maintained features running on a serverless platform.
+- Promoted TDD, SOLID principles, Clean Architecture, and peer programming.
+- Introduced Agile processes, leading morning standups and mentoring junior developers.
+- Azure DevOps pipeline maintenance and troubleshooting.
+- Introduced Entity Framework, OpenAPI, xUnit, and JetBrains Rider.
+- Presented company-wide tech talks and engaged with external stakeholders.
+
+---
+
+### VALD — [vald.com](https://www.vald.com)
+**Software Engineer – Back-end** | January 2023 – May 2023
+
+- Maintained, refactored, and contributed to various legacy REST APIs and microservices.
+- Contributed to the integration testing framework.
+- Promoted TDD and peer programming.
+- Chaired and contributed to various Agile ceremonies.
+
+---
+
+### Situ Systems — [situsystems.com](https://www.situsystems.com)
+**Senior Software Engineer – Full-Stack** | November 2021 – October 2022
+
+- Authored numerous front-end and back-end features.
+- Substantially increased test coverage and improved testing methodologies.
+- Tuned SQL queries, dramatically improving performance in critical reports.
+- Used Pulumi to automate deployment of infrastructure.
+- Implemented CI workflows in Azure DevOps.
+- Contributed to internal development tools.
+
+---
+
+### HUB24 Limited — [hub24.com.au](https://www.hub24.com.au)
+**Data and Full-Stack Engineer** | December 2019 – November 2021
+
+- Authored a sophisticated and successful system for cleaning, transforming, and validating fund transfers between superannuation funds.
+- Maintained strong working relationships with DBAs, architects, BAs, clients (e.g. Bank of New York), and senior management.
+- Provided emergency on-call support across the organisation and managed client infrastructure, triaging and fixing or escalating issues to meet strict SLAs.
+- Updated legacy web applications to deploy using Azure Pipelines.
+- Championed TDD and automated integration testing.
+- Authored, maintained, and supported numerous APIs and ETL projects.
+
+---
+
+### Chandler Personalised Communications — [chandler.com.au](https://www.chandler.com.au)
+**Data and Full-Stack Engineer** | March 2016 – December 2019
+
+- Worked within an ISO 27001 certified organisation meeting strict security standards.
+- Built and maintained web applications servicing government, public utility, and financial sectors.
+- Web design using ASP.NET, Bootstrap, CSS, jQuery, and JavaScript.
+- Database design in Azure SQL Server.
+- Authored SSIS ETL packages to cleanse and process superannuation member data for web, print, and email campaigns.
+- Liaised with technical and non-technical stakeholders to develop bespoke solutions.
+
+---
+
+### WorldSmart POS Solutions — [worldsmart.com.au](https://www.worldsmart.com.au)
+**Software Engineer, QA and Support** | February 2011 – February 2016
+
+- Developed and maintained enterprise software for retail groups.
+- Integrated financial, CRM, and stock modules with MYOB.
+- Provided QA via automated scripting and manual testing.
+- Authored technical and end-user documentation and provided internal training.
+- Maintained internal support utilities and automated scripts.
+- Installed and supported Point of Sale hardware and software.
+
+---
+
+## Contact
+
+- **Email**: [danmarshall909@gmail.com](mailto:danmarshall909@gmail.com)
+- **GitHub**: [github.com/DanMarshall909](https://github.com/DanMarshall909)
+- **LinkedIn**: [linkedin.com/in/developerdan](https://www.linkedin.com/in/developerdan)
+
+---
+
+## References
+
+Available on request.
+
+> *"Dan is an absolute pleasure to work with and I would highly recommend him for any full-stack web development position. We worked together for just under a year and during that time Dan was always friendly, professional and went above and beyond when implementing code and designing systems. He has a keen eye for where things can be improved and is always looking to find the optimal solution to any problem he faces. He writes clean, well-structured code that is easy to maintain. He takes advice and constructive criticism well and brings a positive attitude to every meeting. Dan would be an invaluable addition to any software team."*
+>
+> — **Alistair Doulin**, CTO, Situ Systems Pty Ltd


### PR DESCRIPTION
Adds Dan Marshall's resume as a blog post at /resume. Phone number excluded.

https://claude.ai/code/session_01B7czPxGWSVQEZongit7aBA